### PR TITLE
fix: Correct header clock from disappearing when zooming

### DIFF
--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -111,7 +111,7 @@ export default function Header({
         {/* Right column: Clock (aligned with heading Y) */}
         {headerSettings.showClock && !isMobile && (
           <h2 
-            className="font-light tracking-[0.1em] leading-none select-none hidden md:block" 
+            className="font-light tracking-[0.1em] leading-none select-none" 
             style={{ 
               fontSize: `calc(3.75rem * ${headerScale} * ${clockScale})`, 
               color: 'var(--text-muted)' 


### PR DESCRIPTION
Fixes #5 

<img width="746" height="1128" alt="Screenshot 2026-02-14 at 3 29 01 AM" src="https://github.com/user-attachments/assets/725d4f5d-de98-485d-88df-83ef2fd1b8f4" />
