### PR TITLE
fix: preserve navigation pages when loading incomplete profiles

### DIFF
--- a/src/hooks/useProfiles.js
+++ b/src/hooks/useProfiles.js
@@ -13,6 +13,68 @@ import {
   isValidSnapshot,
 } from '../services/snapshot';
 
+function cloneJson(value, fallback = {}) {
+  try {
+    return JSON.parse(JSON.stringify(value ?? fallback));
+  } catch {
+    return JSON.parse(JSON.stringify(fallback));
+  }
+}
+
+function normalizePagesConfig(candidate, fallback) {
+  const notes = [];
+  const fallbackConfig = cloneJson(fallback, { header: [], pages: ['home'], home: [] });
+
+  if (!candidate || typeof candidate !== 'object') {
+    notes.push('Profile page layout was missing, so current pages were kept.');
+    return { pagesConfig: fallbackConfig, notes };
+  }
+
+  const next = cloneJson(candidate, fallbackConfig);
+  if (!Array.isArray(next.header)) {
+    next.header = Array.isArray(fallbackConfig.header) ? [...fallbackConfig.header] : [];
+  }
+
+  const detectedPages = Object.keys(next)
+    .filter((key) => Array.isArray(next[key]) && !['header', 'settings', 'lights', 'automations'].includes(key));
+
+  if (!Array.isArray(next.pages) || next.pages.length === 0) {
+    next.pages = detectedPages.length > 0
+      ? detectedPages
+      : (Array.isArray(fallbackConfig.pages) && fallbackConfig.pages.length > 0 ? [...fallbackConfig.pages] : ['home']);
+    notes.push('Profile page list was rebuilt.');
+  }
+
+  next.pages = next.pages.filter((id) => !['settings', 'lights', 'automations'].includes(id));
+
+  if (!next.pages.includes('home')) {
+    next.pages = ['home', ...next.pages];
+  }
+
+  if (next.pages.length === 1 && next.pages[0] === 'home') {
+    const extraDetected = detectedPages.filter((id) => id !== 'home');
+    if (extraDetected.length > 0) {
+      next.pages = ['home', ...extraDetected];
+      notes.push('Recovered additional pages from profile data.');
+    }
+  }
+
+  if (next.pages.length === 0) {
+    next.pages = Array.isArray(fallbackConfig.pages) && fallbackConfig.pages.length > 0
+      ? [...fallbackConfig.pages]
+      : ['home'];
+    notes.push('No valid pages were found; previous pages were restored.');
+  }
+
+  next.pages.forEach((pageId) => {
+    if (!Array.isArray(next[pageId])) {
+      next[pageId] = Array.isArray(fallbackConfig[pageId]) ? [...fallbackConfig[pageId]] : [];
+    }
+  });
+
+  return { pagesConfig: next, notes };
+}
+
 /**
  * Hook for managing server-side profiles and templates.
  *
@@ -24,6 +86,7 @@ export function useProfiles({ haUser, contextSetters }) {
   const [profiles, setProfiles] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [loadSummary, setLoadSummary] = useState(null);
   const [backendAvailable, setBackendAvailable] = useState(true);
   const contextSettersRef = useRef(contextSetters);
   contextSettersRef.current = contextSetters;
@@ -87,8 +150,36 @@ export function useProfiles({ haUser, contextSetters }) {
 
   // ── Load a profile onto this device ──
   const loadProfile = useCallback((profile) => {
-    if (!profile?.data) return;
-    applySnapshot(profile.data, contextSettersRef.current);
+    setError(null);
+    setLoadSummary(null);
+
+    if (!profile?.data || typeof profile.data !== 'object') {
+      setError('Profile data is missing or invalid.');
+      return;
+    }
+
+    const currentSnapshot = collectSnapshot();
+    const currentPagesConfig = currentSnapshot?.layout?.pagesConfig;
+
+    const normalizedSnapshot = {
+      ...cloneJson(profile.data, {}),
+      layout: {
+        ...cloneJson(profile.data.layout, {}),
+      },
+    };
+
+    const { pagesConfig, notes } = normalizePagesConfig(
+      normalizedSnapshot.layout.pagesConfig,
+      currentPagesConfig,
+    );
+
+    normalizedSnapshot.layout.pagesConfig = pagesConfig;
+
+    applySnapshot(normalizedSnapshot, contextSettersRef.current);
+
+    if (notes.length > 0) {
+      setLoadSummary(notes.join(' '));
+    }
   }, []);
 
   // ── Edit profile name/label (no data change) ──
@@ -153,6 +244,7 @@ export function useProfiles({ haUser, contextSetters }) {
     profiles,
     loading,
     error,
+    loadSummary,
     backendAvailable,
     saveProfile,
     overwriteProfile,

--- a/src/modals/ConfigModal.jsx
+++ b/src/modals/ConfigModal.jsx
@@ -355,7 +355,7 @@ export default function ConfigModal({
 
     const {
       profiles: profileList,
-      loading, error: profileError, backendAvailable,
+      loading, error: profileError, loadSummary, backendAvailable,
       saveProfile, editProfile, loadProfile, removeProfile,
       startBlank,
       haUser,
@@ -422,6 +422,10 @@ export default function ConfigModal({
 
               {profileError && (
                 <p className="text-xs text-red-400 font-bold">{profileError}</p>
+              )}
+
+              {loadSummary && (
+                <p className="text-xs text-amber-300 font-bold">{loadSummary}</p>
               )}
 
               {/* Profile list */}


### PR DESCRIPTION
## Summary
- hardens profile loading when snapshot page data is incomplete
- repairs/falls back pagesConfig instead of wiping navigation tabs
- shows a small summary message in Profiles tab when fallback repair was applied

## Files
- src/hooks/useProfiles.js
- src/modals/ConfigModal.jsx

## Validation
- npm test (173/173 passing)
- npm run build (passing)

## User impact
Prevents the dashboard from collapsing to only Home when loading malformed/partial profile data (e.g. on tablet kiosk setups).