### PR TITLE
fix(car-card): use entity unit_of_measurement for range instead of hardcoded km

### DIFF
--- a/src/components/cards/CarCard.jsx
+++ b/src/components/cards/CarCard.jsx
@@ -55,6 +55,7 @@ const CarCard = ({
 
   const batteryValue = getNumberState(entities, batteryId);
   const rangeValue = getNumberState(entities, rangeId);
+  const rangeUnit = rangeId ? (entities[rangeId]?.attributes?.unit_of_measurement || 'km') : 'km';
   const climateTempValueRaw = climateId ? getA(climateId, 'current_temperature') : null;
   const climateTempValue = climateTempValueRaw !== null && climateTempValueRaw !== undefined
     ? parseFloat(climateTempValueRaw)
@@ -90,7 +91,7 @@ const CarCard = ({
                 {batteryValue !== null ? `${Math.round(batteryValue)}%` : '--'}
               </span>
               {rangeValue !== null && (
-                <span className="text-xs text-[var(--text-secondary)]">{Math.round(rangeValue)} km</span>
+                <span className="text-xs text-[var(--text-secondary)]">{Math.round(rangeValue)} {rangeUnit}</span>
               )}
             </div>
           </div>
@@ -123,7 +124,7 @@ const CarCard = ({
             </span>
             {isCharging && <Zap className="w-5 h-5 text-green-400 animate-pulse -ml-1 mb-1" fill="currentColor" />}
             {rangeValue !== null && (
-              <span className="text-[var(--text-muted)] font-medium text-base ml-1">{Math.round(rangeValue)}km</span>
+              <span className="text-[var(--text-muted)] font-medium text-base ml-1">{Math.round(rangeValue)}{rangeUnit}</span>
             )}
           </div>
           {pluggedId && (


### PR DESCRIPTION
## Summary
- The EV range display on the Car Card was hardcoded to show 'km', ignoring the actual `unit_of_measurement` from the Home Assistant entity.
- Now reads the unit directly from the entity attributes (e.g. 'mi', 'km', etc.), falling back to 'km' only if no unit is set.
- Fixes both the small and large card views.

## Test plan
- [ ] Configure a Car Card with a range sensor that uses miles (mi)
- [ ] Verify the card displays 'mi' instead of 'km'
- [ ] Verify a sensor using 'km' still shows 'km'
- [ ] Verify a sensor with no unit_of_measurement falls back to 'km'

Closes #23
