### PR TITLE
fix(pills): add Data Source filter and options to Sonos pill

### DIFF
--- a/src/layouts/StatusBar.jsx
+++ b/src/layouts/StatusBar.jsx
@@ -155,7 +155,12 @@ export default function StatusBar({
             }
             
             if (pill.type === 'sonos') {
-              const sonosEntities = getSonosEntities();
+              const sonosIds = pill.mediaFilter
+                ? Object.keys(entities)
+                    .filter(id => id.startsWith('media_player.'))
+                    .filter(id => matchesMediaFilter(id, pill.mediaFilter, pill.mediaFilterMode))
+                : getSonosEntities().map(e => e.entity_id);
+              const sonosEntities = sonosIds.map(id => entities[id]).filter(Boolean);
               
               return (
                 <StatusPill

--- a/src/modals/StatusPillsConfigModal.jsx
+++ b/src/modals/StatusPillsConfigModal.jsx
@@ -584,8 +584,8 @@ export default function StatusPillsConfigModal({
                         </div>
                       )}
 
-                      {/* Emby Filter or Media Player Filter Logic */}
-                      {((pill.type === 'emby' && (pill.mediaSelectionMode || 'filter') === 'filter') || pill.type === 'media_player') && (
+                      {/* Emby / Media Player / Sonos Filter Logic */}
+                      {((pill.type === 'emby' && (pill.mediaSelectionMode || 'filter') === 'filter') || pill.type === 'media_player' || pill.type === 'sonos') && (
                          <div className="space-y-2 bg-[var(--glass-bg)] p-3 rounded-xl">
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-2">
                                 <input
@@ -875,7 +875,7 @@ export default function StatusPillsConfigModal({
                               >
                                 {pill.clickable ? '✓ ' : ''}{t('statusPills.clickable')}
                             </button>
-                            {(pill.type === 'media_player' || pill.type === 'emby') && (
+                            {(pill.type === 'media_player' || pill.type === 'emby' || pill.type === 'sonos') && (
                               <>
                                 <button
                                   onClick={() => updatePill(pill.id, { showCover: !(pill.showCover !== false) })}


### PR DESCRIPTION
## Summary

Fixes #47 — the Sonos pill editor was missing the **Data Source** entity filter and the **Cover** / **Count** option toggles that the Media and Emby pill types already have.

### Root cause

In `StatusPillsConfigModal.jsx`, the filter input condition on line 588 only checked for `emby` and `media_player` types, and the options toggles on line 878 similarly excluded `sonos`. At runtime in `StatusBar.jsx`, the Sonos pill used hardcoded name-based detection (`getSonosEntities()`) and ignored any user-configured `mediaFilter`.

### Changes

| File | Change |
|---|---|
| `StatusPillsConfigModal.jsx` | Added `pill.type === 'sonos'` to the filter input condition and the Cover/Count options toggles |
| `StatusBar.jsx` | Sonos pill now uses `matchesMediaFilter()` when a `mediaFilter` is configured, falling back to the existing `getSonosEntities()` name-based auto-detection when no filter is set |

No new translation keys needed — the Sonos pill now reuses the same existing filter UI and keys as the Media pill.

Closes #47