### PR TITLE
Add media player power controls + responsive transport spacing

### DIFF
--- a/src/components/cards/MediaCards.jsx
+++ b/src/components/cards/MediaCards.jsx
@@ -3,11 +3,13 @@ import {
   ArrowLeftRight,
   Pause,
   Play,
+  Power,
   SkipBack,
   SkipForward,
   Speaker,
   Tv
 } from '../../icons';
+import { getMediaPlayerPowerAction } from '../../utils/mediaPlayerFeatures';
 
 /* ─── Single media player card ─── */
 
@@ -52,6 +54,9 @@ export const MediaPlayerCard = ({
   const subtitle = getA(mpId, 'media_artist') || getA(mpId, 'media_series_title') || getA(mpId, 'media_album_name') || '';
   const picture = getEntityImageUrl(entity?.attributes?.entity_picture);
   const isChannel = getA(mpId, 'media_content_type') === 'channel';
+  const powerAction = getMediaPlayerPowerAction(entity);
+  const canTogglePower = Boolean(powerAction);
+  const isPowerOffAction = powerAction === 'turn_off';
   
   const settings = (cardSettings && settingsKey) ? (cardSettings[settingsKey] || cardSettings[cardId] || {}) : {};
   const artworkMode = settings.artworkMode || 'default';
@@ -68,6 +73,18 @@ export const MediaPlayerCard = ({
           <p className="text-xs font-bold uppercase tracking-widest text-[var(--text-secondary)] opacity-60">{t('media.noneMusic')}</p>
           <div className="flex items-center justify-center gap-2 mt-1"><p className="text-xs uppercase tracking-widest text-[var(--text-muted)] opacity-40 truncate">{name}</p></div>
         </div>
+        {canTogglePower && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              callService('media_player', powerAction, { entity_id: mpId });
+            }}
+            className={`mt-4 p-2.5 rounded-full transition-colors active:scale-95 ${isPowerOffAction ? 'text-red-400 bg-red-500/10 hover:bg-red-500/20' : 'text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'}`}
+            title={isPowerOffAction ? t('status.off') : t('status.on')}
+          >
+            <Power className="w-4 h-4" />
+          </button>
+        )}
       </div>
     );
   }
@@ -100,10 +117,22 @@ export const MediaPlayerCard = ({
           {subtitle && <p className={`${(picture || isCoverMode) ? 'text-gray-300' : 'text-[var(--text-secondary)]'} text-xs truncate font-medium`}>{subtitle}</p>}
         </div>
       </div>
-      <div className="relative z-10 flex items-center justify-center gap-2 sm:gap-6 mt-1 sm:mt-2 px-1 sm:px-0">
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_previous_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-1 sm:p-2 active:scale-90`}><SkipBack className="w-4 h-4 sm:w-6 sm:h-6" /></button>
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_play_pause", { entity_id: mpId }); }} className={`w-9 h-9 sm:w-12 sm:h-12 shrink-0 flex items-center justify-center rounded-full hover:scale-105 transition-transform shadow-lg active:scale-95 ${isCoverMode ? 'bg-white/20 backdrop-blur-md text-white border border-white/30' : 'bg-white text-black'}`}>{isPlaying ? <Pause className="w-4 h-4 sm:w-5 sm:h-5 fill-current" /> : <Play className="w-4 h-4 sm:w-5 sm:h-5 fill-current ml-0.5" />}</button>
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_next_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-1 sm:p-2 active:scale-90`}><SkipForward className="w-4 h-4 sm:w-6 sm:h-6" /></button>
+      <div className="relative z-10 flex items-center justify-center mt-1 sm:mt-2 px-0.5 sm:px-0 gap-[clamp(0.125rem,1.5vw,1.5rem)]">
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_previous_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}><SkipBack className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" /></button>
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_play_pause", { entity_id: mpId }); }} className={`w-[clamp(1.9rem,5.8vw,3rem)] h-[clamp(1.9rem,5.8vw,3rem)] shrink-0 flex items-center justify-center rounded-full hover:scale-105 transition-transform shadow-lg active:scale-95 ${isCoverMode ? 'bg-white/20 backdrop-blur-md text-white border border-white/30' : 'bg-white text-black'}`}>{isPlaying ? <Pause className="w-[clamp(0.85rem,2vw,1.25rem)] h-[clamp(0.85rem,2vw,1.25rem)] fill-current" /> : <Play className="w-[clamp(0.85rem,2vw,1.25rem)] h-[clamp(0.85rem,2vw,1.25rem)] fill-current ml-0.5" />}</button>
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_next_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}><SkipForward className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" /></button>
+        {canTogglePower && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              callService('media_player', powerAction, { entity_id: mpId });
+            }}
+            className={`${(picture || isCoverMode) ? (isPowerOffAction ? 'text-red-300 hover:text-red-100' : 'text-emerald-300 hover:text-emerald-100') : (isPowerOffAction ? 'text-red-400 hover:text-red-500' : 'text-emerald-500 hover:text-emerald-600')} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}
+            title={isPowerOffAction ? t('status.off') : t('status.on')}
+          >
+            <Power className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" />
+          </button>
+        )}
       </div>
     </div>
   );
@@ -157,6 +186,9 @@ export const MediaGroupCard = ({
   const subtitle = getA(mpId, 'media_artist') || getA(mpId, 'media_series_title') || getA(mpId, 'media_album_name') || '';
   const picture = getEntityImageUrl(currentMp.attributes?.entity_picture);
   const isChannel = getA(mpId, 'media_content_type') === 'channel';
+  const powerAction = getMediaPlayerPowerAction(currentMp);
+  const canTogglePower = Boolean(powerAction);
+  const isPowerOffAction = powerAction === 'turn_off';
 
   const cyclePlayers = (e) => {
     e.stopPropagation();
@@ -177,6 +209,18 @@ export const MediaGroupCard = ({
           <p className="text-xs font-bold uppercase tracking-widest text-[var(--text-secondary)] opacity-60">{t('media.noneMusic')}</p>
           <div className="flex items-center justify-center gap-2 mt-1"><p className="text-xs uppercase tracking-widest text-[var(--text-muted)] opacity-40 truncate">{name}</p></div>
         </div>
+        {canTogglePower && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              callService('media_player', powerAction, { entity_id: mpId });
+            }}
+            className={`mt-4 p-2.5 rounded-full transition-colors active:scale-95 ${isPowerOffAction ? 'text-red-400 bg-red-500/10 hover:bg-red-500/20' : 'text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'}`}
+            title={isPowerOffAction ? t('status.off') : t('status.on')}
+          >
+            <Power className="w-4 h-4" />
+          </button>
+        )}
       </div>
     );
   }
@@ -227,10 +271,22 @@ export const MediaGroupCard = ({
           {subtitle && <p className={`${(picture || isCoverMode) ? 'text-gray-300' : 'text-[var(--text-secondary)]'} text-xs truncate font-medium`}>{subtitle}</p>}
         </div>
       </div>
-      <div className="relative z-10 flex items-center justify-center gap-2 sm:gap-6 mt-1 sm:mt-2 px-1 sm:px-0">
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_previous_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-1 sm:p-2 active:scale-90`}><SkipBack className="w-4 h-4 sm:w-6 sm:h-6" /></button>
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_play_pause", { entity_id: mpId }); }} className={`w-9 h-9 sm:w-12 sm:h-12 shrink-0 flex items-center justify-center rounded-full hover:scale-105 transition-transform shadow-lg active:scale-95 ${isCoverMode ? 'bg-white/20 backdrop-blur-md text-white border border-white/30' : 'bg-white text-black'}`}>{isPlaying ? <Pause className="w-4 h-4 sm:w-5 sm:h-5 fill-current" /> : <Play className="w-4 h-4 sm:w-5 sm:h-5 fill-current ml-0.5" />}</button>
-        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_next_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-1 sm:p-2 active:scale-90`}><SkipForward className="w-4 h-4 sm:w-6 sm:h-6" /></button>
+      <div className="relative z-10 flex items-center justify-center mt-1 sm:mt-2 px-0.5 sm:px-0 gap-[clamp(0.125rem,1.5vw,1.5rem)]">
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_previous_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}><SkipBack className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" /></button>
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_play_pause", { entity_id: mpId }); }} className={`w-[clamp(1.9rem,5.8vw,3rem)] h-[clamp(1.9rem,5.8vw,3rem)] shrink-0 flex items-center justify-center rounded-full hover:scale-105 transition-transform shadow-lg active:scale-95 ${isCoverMode ? 'bg-white/20 backdrop-blur-md text-white border border-white/30' : 'bg-white text-black'}`}>{isPlaying ? <Pause className="w-[clamp(0.85rem,2vw,1.25rem)] h-[clamp(0.85rem,2vw,1.25rem)] fill-current" /> : <Play className="w-[clamp(0.85rem,2vw,1.25rem)] h-[clamp(0.85rem,2vw,1.25rem)] fill-current ml-0.5" />}</button>
+        <button onClick={(e) => { e.stopPropagation(); callService("media_player", "media_next_track", { entity_id: mpId }); }} className={`${(picture || isCoverMode) ? 'text-gray-300 hover:text-white' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}><SkipForward className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" /></button>
+        {canTogglePower && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              callService('media_player', powerAction, { entity_id: mpId });
+            }}
+            className={`${(picture || isCoverMode) ? (isPowerOffAction ? 'text-red-300 hover:text-red-100' : 'text-emerald-300 hover:text-emerald-100') : (isPowerOffAction ? 'text-red-400 hover:text-red-500' : 'text-emerald-500 hover:text-emerald-600')} shrink-0 transition-colors p-[clamp(0.15rem,0.9vw,0.5rem)] active:scale-90`}
+            title={isPowerOffAction ? t('status.off') : t('status.on')}
+          >
+            <Power className="w-[clamp(0.85rem,2.2vw,1.5rem)] h-[clamp(0.85rem,2.2vw,1.5rem)]" />
+          </button>
+        )}
       </div>
     </div>
   );

--- a/src/components/pages/MediaPage.jsx
+++ b/src/components/pages/MediaPage.jsx
@@ -14,6 +14,7 @@ import {
   Pause,
   Play,
   SkipForward,
+  Power,
   VolumeX,
   Volume1,
   Volume2,
@@ -21,6 +22,7 @@ import {
   Plus,
   Heart
 } from '../../icons';
+import { getMediaPlayerPowerAction } from '../../utils/mediaPlayerFeatures';
 
 export default function MediaPage({
   pageId,
@@ -80,6 +82,9 @@ export default function MediaPage({
   const mpSeries = mpId ? (getA(mpId, 'media_artist') || getA(mpId, 'media_album_name')) : null;
   const mpName = currentMp?.attributes?.friendly_name || mpId || '';
   const isTV = mpId ? (getA(mpId, 'media_content_type') === 'channel' || getA(mpId, 'device_class') === 'tv') : false;
+  const powerAction = currentMp ? getMediaPlayerPowerAction(currentMp) : null;
+  const canTogglePower = Boolean(powerAction);
+  const isPowerOffAction = powerAction === 'turn_off';
 
   const mpPicture = currentMp ? getEntityImageUrl(currentMp.attributes?.entity_picture) : null;
   const duration = mpId ? getA(mpId, 'media_duration') : null;
@@ -470,35 +475,44 @@ export default function MediaPage({
                 <M3Slider variant="thin" min={0} max={duration || 100} step={1} value={effectivePosition || 0} disabled={!duration} onChange={(e) => callService('media_player', 'media_seek', { entity_id: mpId, seek_position: parseFloat(e.target.value) })} colorClass="bg-white" />
               </div>
 
-              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-2 lg:gap-2 xl:gap-3">
+              <div className="grid grid-cols-[auto_1fr_auto] items-center gap-[clamp(0.25rem,1vw,0.75rem)]">
                 <button
                   onClick={() => callService('media_player', 'shuffle_set', { entity_id: mpId, shuffle: !shuffle })}
-                  className={`p-2 rounded-full transition-all active:scale-95 ${shuffle ? '' : 'text-[var(--text-secondary)] hover:bg-[var(--glass-bg-hover)]'}`}
+                  className={`p-[clamp(0.25rem,1vw,0.5rem)] rounded-full transition-all active:scale-95 ${shuffle ? '' : 'text-[var(--text-secondary)] hover:bg-[var(--glass-bg-hover)]'}`}
                   style={shuffle ? {
                     color: 'var(--text-primary)',
                     backgroundColor: 'var(--glass-bg-hover)'
                   } : undefined}
                   title="Shuffle"
                 >
-                  <Shuffle className="w-4 h-4" />
+                  <Shuffle className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" />
                 </button>
-                <div className="min-w-0 flex items-center justify-center gap-1.5 lg:gap-2 xl:gap-4">
-                  <button onClick={() => callService('media_player', 'media_previous_track', { entity_id: mpId })} className="p-1.5 lg:p-2 hover:bg-[var(--glass-bg-hover)] rounded-full transition-all active:scale-95"><SkipBack className="w-5 h-5 xl:w-6 xl:h-6 text-[var(--text-secondary)]" /></button>
-                  <button onClick={() => callService('media_player', 'media_play_pause', { entity_id: mpId })} className="p-2 lg:p-2.5 xl:p-3 rounded-full transition-all active:scale-95 shadow-lg hover:shadow-xl hover:scale-105 bg-[var(--text-primary)]">
-                    {isPlaying ? <Pause className="w-6 h-6 xl:w-7 xl:h-7" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-6 h-6 xl:w-7 xl:h-7 ml-0.5" color="var(--bg-primary)" fill="var(--bg-primary)" />}
+                <div className="min-w-0 flex items-center justify-center gap-[clamp(0.2rem,1.3vw,1rem)]">
+                  <button onClick={() => callService('media_player', 'media_previous_track', { entity_id: mpId })} className="p-[clamp(0.2rem,1vw,0.5rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-all active:scale-95"><SkipBack className="w-[clamp(1.1rem,2.6vw,1.5rem)] h-[clamp(1.1rem,2.6vw,1.5rem)] text-[var(--text-secondary)]" /></button>
+                  <button onClick={() => callService('media_player', 'media_play_pause', { entity_id: mpId })} className="p-[clamp(0.3rem,1.2vw,0.75rem)] rounded-full transition-all active:scale-95 shadow-lg hover:shadow-xl hover:scale-105 bg-[var(--text-primary)]">
+                    {isPlaying ? <Pause className="w-[clamp(1.1rem,2.8vw,1.75rem)] h-[clamp(1.1rem,2.8vw,1.75rem)]" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-[clamp(1.1rem,2.8vw,1.75rem)] h-[clamp(1.1rem,2.8vw,1.75rem)] ml-0.5" color="var(--bg-primary)" fill="var(--bg-primary)" />}
                   </button>
-                  <button onClick={() => callService('media_player', 'media_next_track', { entity_id: mpId })} className="p-1.5 lg:p-2 hover:bg-[var(--glass-bg-hover)] rounded-full transition-all active:scale-95"><SkipForward className="w-5 h-5 xl:w-6 xl:h-6 text-[var(--text-secondary)]" /></button>
+                  <button onClick={() => callService('media_player', 'media_next_track', { entity_id: mpId })} className="p-[clamp(0.2rem,1vw,0.5rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-all active:scale-95"><SkipForward className="w-[clamp(1.1rem,2.6vw,1.5rem)] h-[clamp(1.1rem,2.6vw,1.5rem)] text-[var(--text-secondary)]" /></button>
+                  {canTogglePower && (
+                    <button
+                      onClick={() => callService('media_player', powerAction, { entity_id: mpId })}
+                      className={`p-[clamp(0.2rem,1vw,0.5rem)] rounded-full transition-all active:scale-95 ${isPowerOffAction ? 'text-red-400 hover:bg-red-500/10' : 'text-emerald-400 hover:bg-emerald-500/10'}`}
+                      title={isPowerOffAction ? t('status.off') : t('status.on')}
+                    >
+                      <Power className="w-[clamp(1.1rem,2.6vw,1.5rem)] h-[clamp(1.1rem,2.6vw,1.5rem)]" />
+                    </button>
+                  )}
                 </div>
                 <button
                   onClick={() => { const modes = ['off', 'one', 'all']; const nextMode = modes[(modes.indexOf(repeat) + 1) % modes.length]; callService('media_player', 'repeat_set', { entity_id: mpId, repeat: nextMode }); }}
-                  className={`p-2 rounded-full transition-all active:scale-95 ${repeat !== 'off' ? '' : 'text-[var(--text-secondary)] hover:bg-[var(--glass-bg-hover)]'}`}
+                  className={`p-[clamp(0.25rem,1vw,0.5rem)] rounded-full transition-all active:scale-95 ${repeat !== 'off' ? '' : 'text-[var(--text-secondary)] hover:bg-[var(--glass-bg-hover)]'}`}
                   style={repeat !== 'off' ? {
                     color: 'var(--text-primary)',
                     backgroundColor: 'var(--glass-bg-hover)'
                   } : undefined}
                   title="Repeat"
                 >
-                  {repeat === 'one' ? <Repeat1 className="w-4 h-4" /> : <Repeat className="w-4 h-4" />}
+                  {repeat === 'one' ? <Repeat1 className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" /> : <Repeat className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" />}
                 </button>
               </div>
             </div>

--- a/src/modals/MediaModal.jsx
+++ b/src/modals/MediaModal.jsx
@@ -4,6 +4,7 @@ import {
   Music,
   Tv,
   Speaker,
+  Power,
   SkipBack,
   SkipForward,
   Play,
@@ -20,6 +21,7 @@ import {
   Heart
 } from '../icons';
 import M3Slider from '../components/ui/M3Slider';
+import { getMediaPlayerPowerAction } from '../utils/mediaPlayerFeatures';
 
 const readJSON = (key, fallback) => {
   try {
@@ -382,6 +384,9 @@ export default function MediaModal({
   const contentType = getA(mpId, 'media_content_type');
   const isChannel = contentType === 'channel';
   const isPlaying = mpState === 'playing';
+  const powerAction = getMediaPlayerPowerAction(currentMp);
+  const canTogglePower = Boolean(powerAction);
+  const isPowerOffAction = powerAction === 'turn_off';
 
   let mpTitle = getA(mpId, 'media_title');
 
@@ -790,18 +795,27 @@ export default function MediaModal({
 
               {isSonos ? (
                 <div className="flex flex-col gap-4 pt-2">
-                  <div className="flex items-center justify-center gap-6">
-                    <button onClick={() => callService("media_player", "shuffle_set", { entity_id: mpId, shuffle: !shuffle })} className={`p-2 rounded-full transition-colors ${shuffle ? 'text-blue-400 bg-blue-500/10' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'}`}><Shuffle className="w-4 h-4" /></button>
+                  <div className="flex items-center justify-center gap-[clamp(0.25rem,1.6vw,1.5rem)]">
+                    <button onClick={() => callService("media_player", "shuffle_set", { entity_id: mpId, shuffle: !shuffle })} className={`p-[clamp(0.25rem,1vw,0.5rem)] rounded-full transition-colors ${shuffle ? 'text-blue-400 bg-blue-500/10' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'}`}><Shuffle className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" /></button>
 
-                    <button onClick={() => callService("media_player", "media_previous_track", { entity_id: mpId })} className="p-2 hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipBack className="w-5 h-5 text-[var(--text-secondary)]" /></button>
-                    <button onClick={() => callService("media_player", "media_play_pause", { entity_id: mpId })} className="p-3 rounded-full transition-colors active:scale-95 shadow-lg bg-[var(--text-primary)]">
-                      {isPlaying ? <Pause className="w-6 h-6" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-6 h-6 ml-0.5" color="var(--bg-primary)" fill="var(--bg-primary)" />}
+                    <button onClick={() => callService("media_player", "media_previous_track", { entity_id: mpId })} className="p-[clamp(0.25rem,1vw,0.5rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipBack className="w-[clamp(1.1rem,2.6vw,1.25rem)] h-[clamp(1.1rem,2.6vw,1.25rem)] text-[var(--text-secondary)]" /></button>
+                    <button onClick={() => callService("media_player", "media_play_pause", { entity_id: mpId })} className="p-[clamp(0.35rem,1.2vw,0.75rem)] rounded-full transition-colors active:scale-95 shadow-lg bg-[var(--text-primary)]">
+                      {isPlaying ? <Pause className="w-[clamp(1.25rem,3vw,1.5rem)] h-[clamp(1.25rem,3vw,1.5rem)]" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-[clamp(1.25rem,3vw,1.5rem)] h-[clamp(1.25rem,3vw,1.5rem)] ml-0.5" color="var(--bg-primary)" fill="var(--bg-primary)" />}
                     </button>
-                    <button onClick={() => callService("media_player", "media_next_track", { entity_id: mpId })} className="p-2 hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipForward className="w-5 h-5 text-[var(--text-secondary)]" /></button>
+                    <button onClick={() => callService("media_player", "media_next_track", { entity_id: mpId })} className="p-[clamp(0.25rem,1vw,0.5rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipForward className="w-[clamp(1.1rem,2.6vw,1.25rem)] h-[clamp(1.1rem,2.6vw,1.25rem)] text-[var(--text-secondary)]" /></button>
 
-                    <button onClick={() => { const modes = ['off', 'one', 'all']; const nextMode = modes[(modes.indexOf(repeat) + 1) % modes.length]; callService("media_player", "repeat_set", { entity_id: mpId, repeat: nextMode }); }} className={`p-2 rounded-full transition-colors ${repeat !== 'off' ? 'text-blue-400 bg-blue-500/10' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'}`}>
-                      {repeat === 'one' ? <Repeat1 className="w-4 h-4" /> : <Repeat className="w-4 h-4" />}
+                    <button onClick={() => { const modes = ['off', 'one', 'all']; const nextMode = modes[(modes.indexOf(repeat) + 1) % modes.length]; callService("media_player", "repeat_set", { entity_id: mpId, repeat: nextMode }); }} className={`p-[clamp(0.25rem,1vw,0.5rem)] rounded-full transition-colors ${repeat !== 'off' ? 'text-blue-400 bg-blue-500/10' : 'text-[var(--text-secondary)] hover:text-[var(--text-primary)]'}`}>
+                      {repeat === 'one' ? <Repeat1 className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" /> : <Repeat className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" />}
                     </button>
+                    {canTogglePower && (
+                      <button
+                        onClick={() => callService('media_player', powerAction, { entity_id: mpId })}
+                        className={`p-[clamp(0.25rem,1vw,0.5rem)] rounded-full transition-colors ${isPowerOffAction ? 'text-red-400 bg-red-500/10 hover:bg-red-500/20' : 'text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'}`}
+                        title={isPowerOffAction ? t('status.off') : t('status.on')}
+                      >
+                        <Power className="w-[clamp(0.9rem,2vw,1rem)] h-[clamp(0.9rem,2vw,1rem)]" />
+                      </button>
+                    )}
                   </div>
 
                   <div className="flex items-center gap-2 px-1 pt-2 border-t border-[var(--glass-border)]">
@@ -834,12 +848,21 @@ export default function MediaModal({
                 </div>
               ) : (
                 <div className="flex flex-col gap-4 pt-2">
-                  <div className="flex items-center justify-center gap-8">
-                    <button onClick={() => callService("media_player", "media_previous_track", { entity_id: mpId })} className="p-4 hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipBack className="w-8 h-8 text-[var(--text-secondary)]" /></button>
-                    <button onClick={() => callService("media_player", "media_play_pause", { entity_id: mpId })} className="p-6 rounded-full transition-colors active:scale-95 shadow-lg bg-[var(--text-primary)]">
-                      {isPlaying ? <Pause className="w-8 h-8" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-8 h-8 ml-1" color="var(--bg-primary)" fill="var(--bg-primary)" />}
+                  <div className="flex items-center justify-center gap-[clamp(0.25rem,1.8vw,1.5rem)]">
+                    <button onClick={() => callService("media_player", "media_previous_track", { entity_id: mpId })} className="p-[clamp(0.45rem,1.4vw,1rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipBack className="w-[clamp(1.25rem,3vw,2rem)] h-[clamp(1.25rem,3vw,2rem)] text-[var(--text-secondary)]" /></button>
+                    <button onClick={() => callService("media_player", "media_play_pause", { entity_id: mpId })} className="p-[clamp(0.65rem,2vw,1.5rem)] rounded-full transition-colors active:scale-95 shadow-lg bg-[var(--text-primary)]">
+                      {isPlaying ? <Pause className="w-[clamp(1.25rem,3vw,2rem)] h-[clamp(1.25rem,3vw,2rem)]" color="var(--bg-primary)" fill="var(--bg-primary)" /> : <Play className="w-[clamp(1.25rem,3vw,2rem)] h-[clamp(1.25rem,3vw,2rem)] ml-1" color="var(--bg-primary)" fill="var(--bg-primary)" />}
                     </button>
-                    <button onClick={() => callService("media_player", "media_next_track", { entity_id: mpId })} className="p-4 hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipForward className="w-8 h-8 text-[var(--text-secondary)]" /></button>
+                    <button onClick={() => callService("media_player", "media_next_track", { entity_id: mpId })} className="p-[clamp(0.45rem,1.4vw,1rem)] hover:bg-[var(--glass-bg-hover)] rounded-full transition-colors active:scale-95"><SkipForward className="w-[clamp(1.25rem,3vw,2rem)] h-[clamp(1.25rem,3vw,2rem)] text-[var(--text-secondary)]" /></button>
+                    {canTogglePower && (
+                      <button
+                        onClick={() => callService('media_player', powerAction, { entity_id: mpId })}
+                        className={`p-[clamp(0.45rem,1.4vw,1rem)] rounded-full transition-colors active:scale-95 ${isPowerOffAction ? 'text-red-400 bg-red-500/10 hover:bg-red-500/20' : 'text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20'}`}
+                        title={isPowerOffAction ? t('status.off') : t('status.on')}
+                      >
+                        <Power className="w-[clamp(1.25rem,3vw,2rem)] h-[clamp(1.25rem,3vw,2rem)]" />
+                      </button>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 px-1 pt-2 border-t border-[var(--glass-border)]">
                     <button

--- a/src/utils/mediaPlayerFeatures.js
+++ b/src/utils/mediaPlayerFeatures.js
@@ -1,0 +1,37 @@
+const MEDIA_PLAYER_FEATURE = {
+  TURN_ON: 128,
+  TURN_OFF: 256,
+};
+
+const supportsMediaPlayerFeature = (supportedFeatures, bitMask) => {
+  if (!Number.isFinite(supportedFeatures)) return false;
+  return (supportedFeatures & bitMask) !== 0;
+};
+
+const getMediaPlayerSupportedFeatures = (entity) => Number(entity?.attributes?.supported_features || 0);
+
+export const canTurnMediaPlayerOn = (entity) => supportsMediaPlayerFeature(
+  getMediaPlayerSupportedFeatures(entity),
+  MEDIA_PLAYER_FEATURE.TURN_ON,
+);
+
+export const canTurnMediaPlayerOff = (entity) => supportsMediaPlayerFeature(
+  getMediaPlayerSupportedFeatures(entity),
+  MEDIA_PLAYER_FEATURE.TURN_OFF,
+);
+
+export const getMediaPlayerPowerAction = (entity) => {
+  if (!entity) return null;
+  const state = String(entity.state || '').toLowerCase();
+  if (!state || state === 'unavailable' || state === 'unknown') return null;
+
+  const canTurnOn = canTurnMediaPlayerOn(entity);
+  const canTurnOff = canTurnMediaPlayerOff(entity);
+
+  if (state === 'off') {
+    return canTurnOn ? 'turn_on' : null;
+  }
+
+  if (canTurnOff) return 'turn_off';
+  return null;
+};


### PR DESCRIPTION
## Summary
- add feature-gated media player power toggle support (`turn_on`/`turn_off`) based on `supported_features`
- show power controls in media modal, media cards (single + group), and media page transport controls
- add shared helper for media-player power action resolution
- make media transport controls compress responsively on narrow widths to prevent overflow

## Technical Changes
- added `src/utils/mediaPlayerFeatures.js`
- updated `src/components/cards/MediaCards.jsx`
- updated `src/modals/MediaModal.jsx`
- updated `src/components/pages/MediaPage.jsx`

## Validation
- `npx eslint src/components/cards/MediaCards.jsx`
- `npx eslint src/components/pages/MediaPage.jsx`
- `npx eslint src/modals/MediaModal.jsx src/components/pages/MediaPage.jsx`
- diagnostics check: no file errors in modified files

## Notes
- existing hook-related lint warnings in `MediaModal.jsx` were pre-existing and unrelated to this PR.