### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -11,6 +11,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = parseInt(process.env.PORT || '3002', 10);
 const isProduction = process.env.NODE_ENV === 'production';
 
+const assetsRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for asset routes
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 const packageJsonPath = join(__dirname, '..', 'package.json');
 let appVersion = 'unknown';
 try {
@@ -95,13 +101,13 @@ if (isProduction) {
       return res.status(503).send('Frontend unavailable');
     };
 
-    app.use('/assets', express.static(assetsPath, {
+    app.use('/assets', assetsRateLimiter, express.static(assetsPath, {
       fallthrough: true,
       immutable: true,
       maxAge: '1y',
     }));
 
-    app.get('/assets/*', (req, res, next) => {
+    app.get('/assets/*', assetsRateLimiter, (req, res, next) => {
       const requested = basename(req.path || '');
       if (!requested) return next();
 


### PR DESCRIPTION
Potential fix for [https://github.com/oyvhov/Tunet/security/code-scanning/19](https://github.com/oyvhov/Tunet/security/code-scanning/19)

In general, the fix is to wrap handlers that perform filesystem access in an Express rate-limiting middleware such as `express-rate-limit`, so that each client can make only a bounded number of such requests per time window. This limits the potential for denial-of-service attacks that rely on triggering many expensive operations.

For this codebase, the smallest, least-disruptive change is to define one or more `rateLimit` middlewares and apply them to the paths that can hit the filesystem: the `/assets/*` route that uses `res.sendFile` and, optionally, the static file serving middlewares. Since `express-rate-limit` is already imported as `rateLimit`, we only need to instantiate a limiter and insert it into the relevant middleware chains. To avoid changing existing functionality, we will keep the same route behavior and just add an extra middleware argument. A reasonable configuration is a per-IP limit (e.g., 100 requests per 15 minutes) for static assets, but that can later be tuned via environment variables if desired.

Concretely:
- Add a `const assetsRateLimiter = rateLimit({...})` definition somewhere after `app` is created and before any `app.use('/assets', ...)` / `app.get('/assets/*', ...)` calls.
- Apply `assetsRateLimiter` to:
  - `app.use('/assets', ...)` by inserting it before `express.static`.
  - `app.get('/assets/*', ...)` by adding it as a middleware parameter before the handler function.
This keeps functionality intact while ensuring the filesystem-based handler is rate-limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
