### PR TITLE
chore: fix post-merge formatter drift

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -101,11 +101,15 @@ if (isProduction) {
       return res.status(503).send('Frontend unavailable');
     };
 
-    app.use('/assets', assetsRateLimiter, express.static(assetsPath, {
-      fallthrough: true,
-      immutable: true,
-      maxAge: '1y',
-    }));
+    app.use(
+      '/assets',
+      assetsRateLimiter,
+      express.static(assetsPath, {
+        fallthrough: true,
+        immutable: true,
+        maxAge: '1y',
+      })
+    );
 
     app.get('/assets/*', assetsRateLimiter, (req, res, next) => {
       const requested = basename(req.path || '');


### PR DESCRIPTION
## Summary
- Re-applies Prettier formatting drift introduced after merging main into ugFixes.
- Ensures 
pm run format:check passes for the current branch head.

## Validation
- 
pm run format:check

## Context
- Prior failing Format Check was attached to already-merged PR #87 and is historical.
